### PR TITLE
Add link to Medium article

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -1,7 +1,7 @@
 name: nightly-test
 on:
   schedule:
-    - cron: '0 0 * * 2-6'
+    - cron: '42 21 * * *'
 jobs:
   run-nightly-test:
     strategy:

--- a/README.md
+++ b/README.md
@@ -101,3 +101,5 @@ We have been extra careful to explain how some statistical bias have been avoide
 for the package to be both user-friendly and correct.
 A [dedicated page](docs/swap_unbiasing.md) deeps dive in the case of the `swap` action.
 * The [API Reference](docs/api.md) details all the technical descriptions needed.
+
+There is also [a Medium article](https://medium.com/earthcube-stories/textnoisr-a-journey-into-noise-calibration-for-nlp-4d39279ef0f6) about this project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,4 +106,6 @@ for the package to be both user-friendly and correct.
 A [dedicated page](swap_unbiasing.md) deeps dive in the case of the `swap` action.
 * The [API Reference](api.md) details all the technical descriptions needed.
 
+There is also [a Medium article](https://medium.com/earthcube-stories/textnoisr-a-journey-into-noise-calibration-for-nlp-4d39279ef0f6) about this project.
+
 *[Character Error Rate]: (=CER) A metric that quantify how noisy is a text. It is number of insert, delete and substitute errors, divided by the total number of characters.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "textnoisr"
-version = "1.1.0"
+version = "1.1.1"
 description = "Add noise to text at the character level"
 authors = [
     "Lilian Sanselme <lilian.sanselme@preligens.com>"


### PR DESCRIPTION
I add a link to the Medium article. I also [modified the cron](https://crontab.guru/#42_22_*_*_*), to make it work on week-ends, and to avoid the action running with the "default" 00:00, when every GitHub server is busy.